### PR TITLE
Add autmated clang-format check on main branch

### DIFF
--- a/.github/workflows/CheckFormatting.yml
+++ b/.github/workflows/CheckFormatting.yml
@@ -1,0 +1,24 @@
+name: clang-format Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - 'src'
+          - 'include'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.4.0
+      with:
+        clang-format-version: '11'
+        check-path: ${{ matrix.path }}


### PR DESCRIPTION
Add Github action to automatically check if code is properly formated, thus keeping the codebase consistent.